### PR TITLE
fix manifest and update project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ _sink_
 ## Running Eventrouter 
 Standup: 
 ```
-$ kubectl create -f https://raw.githubusercontent.com/heptiolabs/eventrouter/master/yaml/eventrouter.yaml
+$ kubectl create -f https://raw.githubusercontent.com/kube-logging/eventrouter/master/yaml/eventrouter.yaml
 ```
 Teardown: 
 ```
-$ kubectl delete -f https://raw.githubusercontent.com/heptiolabs/eventrouter/master/yaml/eventrouter.yaml
+$ kubectl delete -f https://raw.githubusercontent.com/kube-logging/eventrouter/master/yaml/eventrouter.yaml
 ```
 
 ### Inspecting the output 

--- a/yaml/eventrouter.yaml
+++ b/yaml/eventrouter.yaml
@@ -18,7 +18,7 @@ metadata:
   name: eventrouter 
   namespace: kube-system
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: eventrouter 
@@ -27,7 +27,7 @@ rules:
   resources: ["events"]
   verbs: ["get", "watch", "list"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: eventrouter 
@@ -71,7 +71,7 @@ spec:
     spec:
       containers:
         - name: kube-eventrouter
-          image: gcr.io/heptio-images/eventrouter:latest
+          image: ghcr.io/kube-logging/eventrouter:0.4.0
           imagePullPolicy: IfNotPresent
           volumeMounts:
           - name: config-volume


### PR DESCRIPTION
fixes outdated apiversions  in manifest, and updates references from the old fork to kube-logger in the image and README.